### PR TITLE
Use python -m pip in CI workflow

### DIFF
--- a/.github/workflows/Test and publish.yml
+++ b/.github/workflows/Test and publish.yml
@@ -27,7 +27,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libkrb5-dev
         python -m pip install --upgrade pip
-        pip install ".[test]"
+        python -m pip install ".[test]"
         python -c "from ldap3 import GSSAPI; print('GSSAPI OK')"
 
     - name: Install system dependencies for Windows
@@ -35,7 +35,7 @@ jobs:
       run: |
         choco install -y python
         python -m pip install --upgrade pip
-        pip install ".[test,lint,publish]"
+        python -m pip install ".[test,lint,publish]"
         python -c "from ldap3 import KERBEROS; print('KERBEROS OK')"
 
     - name: Display Python version


### PR DESCRIPTION
## Summary
- use python -m pip for Linux/Windows dependency installs

## Testing
- `python -m unittest discover -s src/tests -p "test_*\.py" -v`


------
https://chatgpt.com/codex/tasks/task_b_6899e6f010288324b1687a70d7429d46